### PR TITLE
Improved GP Twirl code in main.lua

### DIFF
--- a/only-up-64-plugin/main.lua
+++ b/only-up-64-plugin/main.lua
@@ -81,6 +81,7 @@ hook_event(HOOK_MARIO_UPDATE, function(m)
         TWIRLING = true
         TWIRL_COUNTER = 0
         m.vel.y = 40.0
+	m.angleVel.y = 4500
         set_mario_action(m, ACT_TWIRLING, 0)
     end
 
@@ -130,6 +131,7 @@ hook_event(HOOK_UPDATE, function()
     if TWIRLING and TWIRL_COUNTER >= TWIRL_COUNT then
         TWIRLING = false
         TWIRL_COUNTER = 0
+	m.angleVel.y = 0
         set_mario_action(m, ACT_FORWARD_ROLLOUT, 0)
     end
 


### PR DESCRIPTION
Fixed a bug where m.angleVel.y wouldn't reset because the ACT_TWIRLING state was interrupted by the ACT_FORWARD_ROLLOUT state.

Whenever m.angleVel.y is reset, however, the next GP Twirl spins very slowly. To improve the animation, the GP Twirl sets m.angleVel.y to 4500 when the action first starts.

The GP Twirl now spins at the same speed every time, and the rotational velocity is properly reset once the twirl ends.